### PR TITLE
Fix ByRef mismatch for CSV host port check

### DIFF
--- a/ThisWorkbook.vba
+++ b/ThisWorkbook.vba
@@ -527,7 +527,9 @@ Private Function LoadCsvFile(filePath As String) As Object
 End Function
 
 ' Summary: Checks CSV data for a host or IP and port and returns success flag and timestamp.
-Private Function CheckCsvForHostPort(csvData As Object, hostOrIp As String, port As String) As Variant
+Private Function CheckCsvForHostPort(ByVal csvData As Object, _
+                                    ByVal hostOrIp As String, _
+                                    ByVal port As String) As Variant
     Dim key As String
     Dim arr As Variant
 


### PR DESCRIPTION
## Summary
- mark parameters of `CheckCsvForHostPort` as `ByVal` to prevent type mismatch when calling with Variant values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866960b4d2c8333916c0cff5d67269e